### PR TITLE
feat: add global mono build configuration

### DIFF
--- a/packages/sst/src/runtime/handlers.ts
+++ b/packages/sst/src/runtime/handlers.ts
@@ -16,6 +16,7 @@ import {usePythonHandler} from "./handlers/python.js";
 import {useRustHandler} from "./handlers/rust.js";
 import {lazy} from "../util/lazy.js";
 import {Semaphore} from "../util/semaphore.js";
+import {isMonoBuildEnabled, isMonoBuildPath} from "./mono-build-config.js";
 
 declare module "../bus.js" {
   export interface Events {
@@ -48,6 +49,8 @@ export interface StartWorkerInput {
   out: string;
   handler: string;
   runtime: string;
+  /** Whether this worker is using mono build mode */
+  isMonoBuild?: boolean;
 }
 
 interface ShouldBuildInput {
@@ -245,7 +248,7 @@ export const useFunctionBuilder = lazy(() => {
         // Optimization: For mono-build, the artifact path is stable and build is handled externally.
         // We can skip the potentially expensive shouldBuild check and rebuild call.
         const existing = artifacts.get(functionID);
-        if (existing?.out.includes(".mono-build")) continue;
+        if (existing && isMonoBuildPath(existing.out)) continue;
 
         const handler = handlers.for(info.runtime!);
         if (

--- a/packages/sst/src/runtime/mono-build-config.ts
+++ b/packages/sst/src/runtime/mono-build-config.ts
@@ -1,0 +1,93 @@
+import path from "path";
+import fsSync from "fs";
+import {useProject} from "../project.js";
+import {lazy} from "../util/lazy.js";
+import {Logger} from "../logger.js";
+
+/**
+ * Global mono build configuration for SST dev mode.
+ *
+ * Mono build mode bundles all Lambda handlers into a single file (.mono-build/index.mjs)
+ * instead of building each handler individually. This significantly speeds up dev mode
+ * by sharing compilation work across all handlers.
+ *
+ * Detection happens once at startup and the result is cached for the session.
+ */
+export const useMonoBuildConfig = lazy(() => {
+  const project = useProject();
+
+  const monoBundleDir = path.join(project.paths.root, ".mono-build");
+  const monoBundlePath = path.join(monoBundleDir, "index.mjs");
+
+  // Check once at startup if mono build exists
+  const enabled = fsSync.existsSync(monoBundlePath);
+
+  if (enabled) {
+    Logger.debug("Mono build mode enabled:", monoBundlePath);
+  }
+
+  return {
+    /**
+     * Whether mono build mode is enabled (detected at startup).
+     * When true, all Node.js handlers use the shared .mono-build bundle.
+     */
+    enabled,
+
+    /**
+     * The mono bundle directory (.mono-build)
+     */
+    dir: monoBundleDir,
+
+    /**
+     * The mono bundle entry file (.mono-build/index.mjs)
+     */
+    entryFile: monoBundlePath,
+
+    /**
+     * The handler string to use for mono build mode
+     */
+    handler: "index.handler",
+
+    /**
+     * Check if a build output path represents a mono build.
+     * This is useful when you have a build result and need to determine its type.
+     */
+    isMonoBuildPath(buildOut: string): boolean {
+      return enabled && buildOut.includes(".mono-build");
+    },
+
+    /**
+     * Get the pool key for a function based on mono build status.
+     * For mono build: shared key (all functions share workers)
+     * For non-mono build: per-function key
+     */
+    getPoolKey(functionID: string, runtime: string, buildOut: string): { key: string; isShared: boolean } {
+      if (enabled && buildOut.includes(".mono-build")) {
+        return { key: `${runtime}:mono-build`, isShared: true };
+      }
+      return { key: `${runtime}:${functionID}`, isShared: false };
+    },
+  };
+});
+
+/**
+ * Quick check for mono build mode without full config initialization.
+ * Use this for simple boolean checks where you don't need the full config.
+ */
+export function isMonoBuildEnabled(): boolean {
+  return useMonoBuildConfig().enabled;
+}
+
+/**
+ * Get the mono build directory path.
+ */
+export function getMonoBuildDir(): string {
+  return useMonoBuildConfig().dir;
+}
+
+/**
+ * Check if a path represents a mono build output.
+ */
+export function isMonoBuildPath(buildOut: string): boolean {
+  return useMonoBuildConfig().isMonoBuildPath(buildOut);
+}

--- a/packages/sst/support/nodejs-runtime/index.ts
+++ b/packages/sst/support/nodejs-runtime/index.ts
@@ -9,9 +9,9 @@ import { Context as LambdaContext } from "aws-lambda";
 
 const input = workerData;
 
-// Check for mono-bundle mode: if handler is "index.handler" and index.mjs exists in out directory
+// Check for mono-bundle mode: use the flag passed from parent process, fallback to file check
 const monoBundlePath = path.join(input.out, "index.mjs");
-const useMonoBundle = input.handler === "index.handler" && fs.existsSync(monoBundlePath);
+const useMonoBundle = input.isMonoBuild ?? (input.handler === "index.handler" && fs.existsSync(monoBundlePath));
 
 let file: string;
 let handlerName: string;

--- a/packages/sst/support/nodejs-runtime/index.ts
+++ b/packages/sst/support/nodejs-runtime/index.ts
@@ -166,9 +166,10 @@ while (true) {
       clientContext:
         JSON.parse(result.headers["lambda-runtime-client-context"]) ??
         undefined,
-      functionName: process.env.AWS_LAMBDA_FUNCTION_NAME!,
-      functionVersion: process.env.AWS_LAMBDA_FUNCTION_VERSION!,
-      memoryLimitInMB: process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE!,
+      // Per-invocation function context from headers (essential for mono-build shared workers)
+      functionName: result.headers["lambda-runtime-function-name"] || process.env.AWS_LAMBDA_FUNCTION_NAME!,
+      functionVersion: result.headers["lambda-runtime-function-version"] || process.env.AWS_LAMBDA_FUNCTION_VERSION!,
+      memoryLimitInMB: result.headers["lambda-runtime-function-memory-size"] || process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE!,
       logGroupName: result.headers["lambda-runtime-log-group-name"],
       logStreamName: result.headers["lambda-runtime-log-stream-name"],
       callbackWaitsForEmptyEventLoop: {


### PR DESCRIPTION
Add centralized mono build configuration to replace ad-hoc detection
patterns throughout the codebase. This improves maintainability and
ensures consistent mono build detection across all components.

Changes:
- Create mono-build-config.ts with lazy initialization and cached state
- Update handlers/node.ts to use global config instead of file checks
- Update handlers.ts to use isMonoBuildPath helper
- Update workers.ts to use config for pool key calculation
- Pass isMonoBuild flag to nodejs-runtime via workerData

The global config is initialized once at startup and provides:
- enabled: boolean flag for mono build mode
- dir/entryFile: paths to the mono bundle
- isMonoBuildPath(): check if a path is a mono build output
- getPoolKey(): get pool key based on mono build status