### PR TITLE
docs: clarify why timeout is cleared on ack in live lambda

### DIFF
--- a/packages/sst/support/bridge/live-lambda.ts
+++ b/packages/sst/support/bridge/live-lambda.ts
@@ -148,6 +148,9 @@ export async function handler(event: any, context: any) {
     onMessage = (evt) => {
       if (evt.type === "function.ack") {
         if (evt.properties.workerID === workerID) {
+          // Clear the timeout once we receive ACK - this means the local dev server
+          // received the request and is processing it. The function can now take
+          // as long as it needs (up to Lambda's own deadline).
           clearTimeout(timeout);
         }
       }


### PR DESCRIPTION
Add comment explaining that clearing the timeout on ACK is intentional.
The ACK confirms the local dev server received the request and is
processing it, so the function can now take as long as it needs
(up to Lambda's own deadline).

Note: The separate-log-changes branch has a bug where it removed
this clearTimeout call and added a comment saying "Don't clear
timeout on ACK" - that is incorrect behavior.