### PR TITLE
refactor: abstract logging systems to follow DRY principles

### DIFF
--- a/packages/sst/src/iot.ts
+++ b/packages/sst/src/iot.ts
@@ -3,6 +3,7 @@ import { useAWSClient, useAWSCredentials } from "./credentials.js";
 import { VisibleError } from "./error.js";
 import { lazy } from "./util/lazy.js";
 import { Logger } from "./logger.js";
+import { logIotRx } from "./runtime/debug-bridge-logging.js";
 
 export const useIOTEndpoint = lazy(async () => {
   const iot = useAWSClient(IoTClient);
@@ -145,6 +146,8 @@ export const useIOT = lazy(async () => {
   device.on("message", (_topic, buffer: Buffer) => {
     const fragment = JSON.parse(buffer.toString());
     if (!fragment.id) {
+      const requestID = fragment.properties?.requestID;
+      logIotRx(`Received ${fragment.type} reqId=${requestID?.slice(0, 8) || 'N/A'}`);
       bus.publish(fragment.type, fragment.properties);
       return;
     }
@@ -164,6 +167,8 @@ export const useIOT = lazy(async () => {
       fragments.delete(fragment.id);
       const evt = JSON.parse(data) as EventPayload;
       if (evt.sourceID === bus.sourceID) return;
+      const requestID = (evt.properties as any)?.requestID;
+      logIotRx(`Received ${evt.type} reqId=${requestID?.slice(0, 8) || 'N/A'} (${fragment.count} fragments)`);
       bus.publish(evt.type, evt.properties);
     }
   });

--- a/packages/sst/src/runtime/debug-bridge-logging.ts
+++ b/packages/sst/src/runtime/debug-bridge-logging.ts
@@ -1,0 +1,114 @@
+import { createDebugFileLogger, DebugFileLogger } from "./debug-file-logger.js";
+
+/**
+ * Debug logging for SST dev bridge components
+ *
+ * Enable with: SST_DEBUG_BRIDGE=true
+ *
+ * Log files:
+ * - .sst/debug-workers.log - Worker pool and invocation handling
+ * - .sst/debug-server.log  - Runtime server request/response handling
+ * - .sst/debug-iot.log     - IoT message publishing and receiving
+ */
+
+const DEBUG_BRIDGE = process.env.SST_DEBUG_BRIDGE === "true";
+
+// Lazy-initialized loggers
+let workersLogger: DebugFileLogger | null = null;
+let serverLogger: DebugFileLogger | null = null;
+let iotLogger: DebugFileLogger | null = null;
+
+function getWorkersLogger(): DebugFileLogger | null {
+  if (!DEBUG_BRIDGE) return null;
+  if (!workersLogger) {
+    workersLogger = createDebugFileLogger({
+      filePath: ".sst/debug-workers.log",
+      sessionName: "WORKERS",
+      width: 120,
+    });
+  }
+  return workersLogger;
+}
+
+function getServerLogger(): DebugFileLogger | null {
+  if (!DEBUG_BRIDGE) return null;
+  if (!serverLogger) {
+    serverLogger = createDebugFileLogger({
+      filePath: ".sst/debug-server.log",
+      sessionName: "SERVER",
+      width: 120,
+    });
+  }
+  return serverLogger;
+}
+
+function getIotLogger(): DebugFileLogger | null {
+  if (!DEBUG_BRIDGE) return null;
+  if (!iotLogger) {
+    iotLogger = createDebugFileLogger({
+      filePath: ".sst/debug-iot.log",
+      sessionName: "IOT",
+      width: 120,
+    });
+  }
+  return iotLogger;
+}
+
+/**
+ * Log debug message for workers component
+ * Outputs to console and optionally to .sst/debug-workers.log
+ */
+export function logWorkers(message: string, details?: Record<string, any>) {
+  console.log(`[WORKERS] ${message}`);
+
+  const logger = getWorkersLogger();
+  if (logger) {
+    logger.log("WORKERS", { msg: message, ...details });
+  }
+}
+
+/**
+ * Log debug message for server component
+ * Outputs to console and optionally to .sst/debug-server.log
+ */
+export function logServer(message: string, details?: Record<string, any>) {
+  console.log(`[SERVER] ${message}`);
+
+  const logger = getServerLogger();
+  if (logger) {
+    logger.log("SERVER", { msg: message, ...details });
+  }
+}
+
+/**
+ * Log debug message for IoT component (publishing)
+ * Outputs to console and optionally to .sst/debug-iot.log
+ */
+export function logIot(message: string, details?: Record<string, any>) {
+  console.log(`[IOT] ${message}`);
+
+  const logger = getIotLogger();
+  if (logger) {
+    logger.log("IOT", { msg: message, ...details });
+  }
+}
+
+/**
+ * Log debug message for IoT component (receiving)
+ * Outputs to console and optionally to .sst/debug-iot.log
+ */
+export function logIotRx(message: string, details?: Record<string, any>) {
+  console.log(`[IOT-RX] ${message}`);
+
+  const logger = getIotLogger();
+  if (logger) {
+    logger.log("IOT-RX", { msg: message, ...details });
+  }
+}
+
+/**
+ * Check if bridge debug logging is enabled
+ */
+export function isDebugBridgeEnabled(): boolean {
+  return DEBUG_BRIDGE;
+}

--- a/packages/sst/src/runtime/debug-file-logger.ts
+++ b/packages/sst/src/runtime/debug-file-logger.ts
@@ -1,0 +1,228 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Configuration for creating a debug file logger
+ */
+export interface DebugFileLoggerConfig {
+  /** Log file path (relative paths are relative to CWD) */
+  filePath: string;
+  /** Optional environment variable to enable/disable logging (if not set, logging is always enabled) */
+  envVar?: string;
+  /** Name for session markers (e.g., "POOL", "TRACE") */
+  sessionName: string;
+  /** Optional header line content for session start */
+  sessionHeader?: string;
+  /** Column width for padding (default: 80) */
+  width?: number;
+}
+
+/**
+ * Debug file logger instance
+ */
+export interface DebugFileLogger {
+  /** Log a message with timestamp and formatted details */
+  log: (action: string, details?: Record<string, any>) => void;
+  /** Log a raw line (no formatting) */
+  logRaw: (line: string) => void;
+  /** Check if logging is enabled */
+  isEnabled: () => boolean;
+  /** Write session end marker and close the stream */
+  close: (summary?: string) => void;
+  /** Get the write stream (for advanced use cases) */
+  getStream: () => fs.WriteStream | null;
+}
+
+// Active loggers registry (for cleanup)
+const activeLoggers = new Map<string, fs.WriteStream>();
+
+// Cleanup on process exit
+process.on("exit", () => {
+  for (const stream of activeLoggers.values()) {
+    try {
+      stream.end();
+    } catch {}
+  }
+});
+
+/**
+ * Create a debug file logger with consistent formatting
+ *
+ * Features:
+ * - File-based logging to configurable path
+ * - Optional enable/disable via environment variable
+ * - Session start/end markers
+ * - Consistent timestamp formatting (HH:MM:SS.mmm)
+ * - Automatic directory creation
+ *
+ * @example
+ * ```ts
+ * const logger = createDebugFileLogger({
+ *   filePath: ".sst/debug-workers.log",
+ *   envVar: "SST_DEBUG_WORKERS",
+ *   sessionName: "WORKERS",
+ * });
+ *
+ * logger.log("REQUEST", { path: "/api/test", elapsed: 50 });
+ * // Output: [14:30:45.123] REQUEST path=/api/test elapsed=50
+ * ```
+ */
+export function createDebugFileLogger(
+  config: DebugFileLoggerConfig
+): DebugFileLogger {
+  const { filePath, envVar, sessionName, sessionHeader, width = 80 } = config;
+
+  let stream: fs.WriteStream | null = null;
+  let initialized = false;
+
+  function isEnabled(): boolean {
+    // If no envVar specified, always enabled
+    if (!envVar) return true;
+    return process.env[envVar] === "true";
+  }
+
+  function initLogFile(): boolean {
+    if (initialized) return stream !== null;
+    initialized = true;
+
+    if (!isEnabled()) return false;
+
+    try {
+      const logDir = path.dirname(filePath);
+      if (!fs.existsSync(logDir)) {
+        fs.mkdirSync(logDir, { recursive: true });
+      }
+
+      stream = fs.createWriteStream(filePath, { flags: "w" });
+      activeLoggers.set(filePath, stream);
+
+      // Write session start marker
+      const header = sessionHeader ? ` | ${sessionHeader}` : "";
+      stream.write(
+        "\n" +
+          "=".repeat(width) +
+          "\n" +
+          `[${sessionName} SESSION START] ${new Date().toISOString()}${header}\n` +
+          "=".repeat(width) +
+          "\n"
+      );
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  function formatTimestamp(): string {
+    return new Date().toISOString().slice(11, 23); // HH:MM:SS.mmm
+  }
+
+  function formatDetails(details: Record<string, any>): string {
+    return Object.entries(details)
+      .filter(([_, v]) => v !== undefined)
+      .map(([k, v]) => {
+        if (typeof v === "object") {
+          return `${k}=${JSON.stringify(v)}`;
+        }
+        return `${k}=${v}`;
+      })
+      .join(" ");
+  }
+
+  return {
+    log(action: string, details: Record<string, any> = {}) {
+      if (!initLogFile() || !stream) return;
+
+      const timestamp = formatTimestamp();
+      const detailStr = formatDetails(details);
+      const line = `[${timestamp}] ${action.padEnd(20)} ${detailStr}\n`;
+
+      stream.write(line);
+    },
+
+    logRaw(line: string) {
+      if (!initLogFile() || !stream) return;
+      stream.write(line.endsWith("\n") ? line : line + "\n");
+    },
+
+    isEnabled,
+
+    close(summary?: string) {
+      if (!stream) return;
+
+      const endMarker =
+        "\n" +
+        "-".repeat(width) +
+        "\n" +
+        `[${sessionName} SESSION END] ${new Date().toISOString()}\n` +
+        (summary ? summary + "\n" : "") +
+        "-".repeat(width) +
+        "\n";
+
+      stream.write(endMarker);
+      stream.end();
+      activeLoggers.delete(filePath);
+      stream = null;
+    },
+
+    getStream() {
+      initLogFile();
+      return stream;
+    },
+  };
+}
+
+/**
+ * Create a simple console+file logger for debug output
+ * Logs to both console and a file with consistent formatting
+ */
+export interface ConsoleFileLoggerConfig {
+  /** Log file path */
+  filePath: string;
+  /** Prefix for console output (e.g., "[WORKERS]") */
+  prefix: string;
+  /** Session name for file markers */
+  sessionName: string;
+}
+
+export interface ConsoleFileLogger {
+  /** Log a message to both console and file */
+  log: (message: string) => void;
+  /** Check if file logging is enabled */
+  isEnabled: () => boolean;
+  /** Close the file stream */
+  close: () => void;
+}
+
+/**
+ * Create a logger that writes to both console and a file
+ * Always writes to console, writes to file when SST_DEBUG_BRIDGE is set
+ */
+export function createConsoleFileLogger(
+  config: ConsoleFileLoggerConfig
+): ConsoleFileLogger {
+  const { filePath, prefix, sessionName } = config;
+
+  const fileLogger = createDebugFileLogger({
+    filePath,
+    envVar: "SST_DEBUG_BRIDGE",
+    sessionName,
+    width: 100,
+  });
+
+  return {
+    log(message: string) {
+      // Always log to console
+      console.log(`${prefix} ${message}`);
+
+      // Also log to file if enabled
+      if (fileLogger.isEnabled()) {
+        const timestamp = new Date().toISOString().slice(11, 23);
+        fileLogger.logRaw(`[${timestamp}] ${prefix} ${message}`);
+      }
+    },
+
+    isEnabled: fileLogger.isEnabled,
+    close: () => fileLogger.close(),
+  };
+}

--- a/packages/sst/src/runtime/iot.ts
+++ b/packages/sst/src/runtime/iot.ts
@@ -2,6 +2,7 @@ import { useBus } from "../bus.js";
 import { useIOT } from "../iot.js";
 import { lazy } from "../util/lazy.js";
 import { logInvokeTrace } from "./worker-pool-logging.js";
+import { logIot } from "./debug-bridge-logging.js";
 
 export const useIOTBridge = lazy(async () => {
   const bus = useBus();
@@ -9,27 +10,38 @@ export const useIOTBridge = lazy(async () => {
   const topic = `${iot.prefix}/events`;
 
   bus.subscribe("function.success", async (evt) => {
-    iot.publish(
-      topic + "/" + evt.properties.workerID,
+    const { workerID, requestID } = evt.properties;
+    logIot(`reqId=${requestID?.slice(0, 8)} Publishing function.success to worker ${workerID.slice(0, 8)}`);
+    const startTime = Date.now();
+    await iot.publish(
+      topic + "/" + workerID,
       "function.success",
       evt.properties
     );
+    logIot(`reqId=${requestID?.slice(0, 8)} function.success published in ${Date.now() - startTime}ms`);
   });
   bus.subscribe("function.error", async (evt) => {
-    iot.publish(
-      topic + "/" + evt.properties.workerID,
+    const { workerID, requestID } = evt.properties;
+    logIot(`reqId=${requestID?.slice(0, 8)} Publishing function.error to worker ${workerID.slice(0, 8)}`);
+    const startTime = Date.now();
+    await iot.publish(
+      topic + "/" + workerID,
       "function.error",
       evt.properties
     );
+    logIot(`reqId=${requestID?.slice(0, 8)} function.error published in ${Date.now() - startTime}ms`);
   });
   bus.subscribe("function.ack", async (evt) => {
-    const workerID = evt.properties.workerID;
+    const { workerID, requestID } = evt.properties;
+    logIot(`reqId=${requestID?.slice(0, 8)} Publishing function.ack to worker ${workerID.slice(0, 8)}`);
     logInvokeTrace("IOT_ACK_START", workerID, `worker=${workerID.slice(0, 8)}`);
+    const startTime = Date.now();
     await iot.publish(
       topic + "/" + workerID,
       "function.ack",
       evt.properties
     );
+    logIot(`reqId=${requestID?.slice(0, 8)} function.ack published in ${Date.now() - startTime}ms`);
     logInvokeTrace("IOT_ACK_DONE", workerID, `worker=${workerID.slice(0, 8)}`);
   });
 });


### PR DESCRIPTION
- Create debug-file-logger.ts: Abstract file logger factory with
  configurable file paths, environment variable controls, session
  markers, and consistent timestamp formatting

- Create debug-bridge-logging.ts: Centralized debug logging module
  that exports logWorkers, logServer, logIot, logIotRx functions.
  Logs to both console and separate files when SST_DEBUG_BRIDGE=true:
  - .sst/debug-workers.log
  - .sst/debug-server.log
  - .sst/debug-iot.log

- Refactor worker-pool-logging.ts to use the new abstract logger,
  keeping the specialized bottleneck detection and metrics tracking

- Update workers.ts, server.ts, runtime/iot.ts, and src/iot.ts to
  use the new centralized logging functions instead of direct
  console.log calls

Log files remain separate as requested for easy filtering.